### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides tools for interacting with the Trello API. Built on the Generic MCP Server Template.
 
+<a href="https://glama.ai/mcp/servers/@v4lheru/trello-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@v4lheru/trello-mcp-server/badge" alt="trello-mcp-server MCP server" />
+</a>
+
 ## Features
 
 - **Trello Integration**: Complete access to Trello boards, lists, cards, and more


### PR DESCRIPTION
This PR adds a badge for the [trello-mcp-server](https://glama.ai/mcp/servers/@v4lheru/trello-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@v4lheru/trello-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@v4lheru/trello-mcp-server/badge" alt="trello-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.