### PR TITLE
fix: remove duplicate tool name definitions

### DIFF
--- a/src/tools/label-tool-handlers.ts
+++ b/src/tools/label-tool-handlers.ts
@@ -58,16 +58,6 @@ export const labelToolHandlers = {
     },
 
     /**
-     * Get all labels on a board
-     * @param args - Tool arguments
-     * @returns Promise resolving to the labels
-     */
-    get_board_labels: async (args: any) => {
-        const labelService = ServiceFactory.getInstance().getLabelService();
-        return labelService.getBoardLabels(args.boardId);
-    },
-
-    /**
      * Update the name of a label
      * @param args - Tool arguments
      * @returns Promise resolving to the updated label

--- a/src/tools/label-tools.ts
+++ b/src/tools/label-tools.ts
@@ -89,20 +89,6 @@ export const labelTools = [
         }
     },
     {
-        name: "get_board_labels",
-        description: "Get all labels on a board. Use this tool to see the available labels on a board.",
-        inputSchema: {
-            type: "object",
-            properties: {
-                boardId: {
-                    type: "string",
-                    description: "ID of the board"
-                }
-            },
-            required: ["boardId"]
-        }
-    },
-    {
         name: "update_label_name",
         description: "Update the name of a label. Use this tool to rename a label.",
         inputSchema: {

--- a/src/tools/member-tool-handlers.ts
+++ b/src/tools/member-tool-handlers.ts
@@ -112,16 +112,6 @@ export const memberToolHandlers = {
     },
 
     /**
-     * Get members of a board
-     * @param args - Tool arguments
-     * @returns Promise resolving to the members
-     */
-    get_board_members: async (args: any) => {
-        const memberService = ServiceFactory.getInstance().getMemberService();
-        return memberService.getBoardMembers(args.boardId);
-    },
-
-    /**
      * Get members of an organization
      * @param args - Tool arguments
      * @returns Promise resolving to the members

--- a/src/tools/member-tools.ts
+++ b/src/tools/member-tools.ts
@@ -211,20 +211,6 @@ export const memberTools = [
         }
     },
     {
-        name: "get_board_members",
-        description: "Get members of a board. Use this to see who has access to a board.",
-        inputSchema: {
-            type: "object",
-            properties: {
-                boardId: {
-                    type: "string",
-                    description: "ID of the board"
-                }
-            },
-            required: ["boardId"]
-        }
-    },
-    {
         name: "get_organization_members",
         description: "Get members of an organization. Use this to see who belongs to a workspace.",
         inputSchema: {


### PR DESCRIPTION
## Summary

Fixes duplicate tool name registrations that cause MCP clients to reject the server.

**Problem:** The server registers the same tool names twice from different files:
- `get_board_labels` defined in both `board-tools.ts` and `label-tools.ts`
- `get_board_members` defined in both `board-tools.ts` and `member-tools.ts`

This causes Claude Code (VS Code extension) to fail on startup with:
```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"tools: Tool names must be unique."}}
```

**Impact:** This completely breaks the Claude Code VS Code extension, making it unusable when this MCP server is configured.

## Changes

Removed the duplicate definitions from `label-tools.ts` and `member-tools.ts`. The tools remain in `board-tools.ts` since they query board state (take `boardId` as input).

## Test plan

- [x] Build succeeds
- [x] Verify each tool name appears only once in the codebase
- [x] Tested in Claude Code VS Code extension - error is gone, extension works